### PR TITLE
fix: encode and decode for structures that contain dinamic values

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -216,7 +216,7 @@ func (m *Method) ID() []byte {
 
 // Encode encodes the inputs with this function
 func (m *Method) Encode(args interface{}) ([]byte, error) {
-	data, err := Encode(args, m.Inputs)
+	data, err := Encode(args, m.Inputs, true)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (m *Method) Decode(data []byte) (map[string]interface{}, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("empty response")
 	}
-	respInterface, err := Decode(m.Outputs, data)
+	respInterface, err := Decode(m.Outputs, data, true)
 	if err != nil {
 		return nil, err
 	}

--- a/abi/decode.go
+++ b/abi/decode.go
@@ -15,11 +15,15 @@ const (
 	storageSlotSize = 32
 )
 
-// Decode decodes the input with a given type
+// Decode decodes the input with a given type“
 func Decode(t *Type, input []byte) (interface{}, error) {
 	if len(input) == 0 {
 		return nil, fmt.Errorf("empty input")
 	}
+	if t.kind == KindTuple {
+		t.isRootTuple = true
+	}
+
 	val, _, err := decode(t, input)
 	return val, err
 }
@@ -66,6 +70,14 @@ func decode(t *Type, input []byte) (interface{}, []byte, error) {
 
 	switch t.kind {
 	case KindTuple:
+		if t.isRootTuple && t.isDynamicType() {
+			offset, err := readOffset(input, len(input))
+			if err != nil {
+				return nil, nil, err
+			}
+			return decodeTuple(t, input[offset:])
+		}
+
 		return decodeTuple(t, input)
 
 	case KindSlice:

--- a/abi/decode.go
+++ b/abi/decode.go
@@ -16,11 +16,11 @@ const (
 )
 
 // Decode decodes the input with a given type“
-func Decode(t *Type, input []byte) (interface{}, error) {
+func Decode(t *Type, input []byte, isFunctionArgument ...any) (interface{}, error) {
 	if len(input) == 0 {
 		return nil, fmt.Errorf("empty input")
 	}
-	if t.kind == KindTuple {
+	if t.kind == KindTuple && len(isFunctionArgument) == 0 {
 		t.isRootTuple = true
 	}
 

--- a/abi/encode.go
+++ b/abi/encode.go
@@ -18,8 +18,8 @@ var (
 )
 
 // Encode encodes a value
-func Encode(v interface{}, t *Type) ([]byte, error) {
-	if t.kind == KindTuple {
+func Encode(v interface{}, t *Type, isFunctionArgument ...bool) ([]byte, error) {
+	if t.kind == KindTuple && len(isFunctionArgument) == 0 {
 		t.isRootTuple = true
 	}
 

--- a/abi/encode.go
+++ b/abi/encode.go
@@ -1,6 +1,7 @@
 package abi
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -18,6 +19,10 @@ var (
 
 // Encode encodes a value
 func Encode(v interface{}, t *Type) ([]byte, error) {
+	if t.kind == KindTuple {
+		t.isRootTuple = true
+	}
+
 	return encode(reflect.ValueOf(v), t)
 }
 
@@ -159,6 +164,12 @@ func encodeTuple(v reflect.Value, t *Type) ([]byte, error) {
 		} else {
 			ret = append(ret, val...)
 		}
+	}
+
+	if t.isRootTuple && t.isDynamicType() {
+		// creates a 32 bytes offset to the head of the dynamic data
+		offset32 := append(bytes.Repeat([]byte{0}, 31), storageSlotSize)
+		ret = append(offset32, ret...)
 	}
 
 	return append(ret, tail...), nil

--- a/abi/revert.go
+++ b/abi/revert.go
@@ -14,7 +14,7 @@ func UnpackRevertError(b []byte) (string, error) {
 
 	b = b[4:]
 	tt := MustNewType("tuple(string)")
-	vals, err := tt.Decode(b)
+	vals, err := tt.Decode(b, true)
 	if err != nil {
 		return "", err
 	}

--- a/abi/type.go
+++ b/abi/type.go
@@ -138,8 +138,8 @@ func (t *Type) ParseLog(log *ethgo.Log) (map[string]interface{}, error) {
 }
 
 // Decode decodes an object using this type
-func (t *Type) Decode(input []byte) (interface{}, error) {
-	return Decode(t, input)
+func (t *Type) Decode(input []byte, isFunctionArgument ...any) (interface{}, error) {
+	return Decode(t, input, isFunctionArgument...)
 }
 
 // DecodeStruct decodes an object using this type to the out param

--- a/abi/type.go
+++ b/abi/type.go
@@ -99,12 +99,13 @@ type TupleElem struct {
 
 // Type is an ABI type
 type Type struct {
-	kind  Kind
-	size  int
-	elem  *Type
-	tuple []*TupleElem
-	t     reflect.Type
-	itype string
+	kind        Kind
+	size        int
+	elem        *Type
+	tuple       []*TupleElem
+	t           reflect.Type
+	itype       string
+	isRootTuple bool
 }
 
 func NewTupleType(inputs []*TupleElem) *Type {


### PR DESCRIPTION
Fixed encoding & decoding issues according to solidity encoding/decoding. 

The issue was offset on bytes that represent **structure** that has dynamic values in it.
Only root **tuple** has that offset, children tuples **do not possess offset** if they contain dynamic values.