### PR TITLE
feat: update solidity version

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -88,6 +88,7 @@ func NewABI(s string) (*ABI, error) {
 	return NewABIFromReader(bytes.NewReader([]byte(s)))
 }
 
+// NewABIFromSlice returns a parsed ABI struct from a slice of ABI fields that represent the contract
 func NewABIFromSlice(abi []compiler.AbiField) (*ABI, error) {
 	a := &ABI{}
 
@@ -99,7 +100,7 @@ func NewABIFromSlice(abi []compiler.AbiField) (*ABI, error) {
 			}
 			input, err := NewTupleTypeFromFields(field.Inputs)
 			if err != nil {
-				panic(err)
+				return nil, err
 			}
 			a.Constructor = &Method{
 				Inputs: input,
@@ -113,11 +114,11 @@ func NewABIFromSlice(abi []compiler.AbiField) (*ABI, error) {
 
 			inputs, err := NewTupleTypeFromFields(field.Inputs)
 			if err != nil {
-				panic(err)
+				return nil, err
 			}
 			outputs, err := NewTupleTypeFromFields(field.Outputs)
 			if err != nil {
-				panic(err)
+				return nil, err
 			}
 			method := &Method{
 				Name:    field.Name,
@@ -130,7 +131,7 @@ func NewABIFromSlice(abi []compiler.AbiField) (*ABI, error) {
 		case "event":
 			input, err := NewTupleTypeFromFields(field.Inputs)
 			if err != nil {
-				panic(err)
+				return nil, err
 			}
 			event := &Event{
 				Name:      field.Name,
@@ -142,7 +143,7 @@ func NewABIFromSlice(abi []compiler.AbiField) (*ABI, error) {
 		case "error":
 			input, err := NewTupleTypeFromFields(field.Inputs)
 			if err != nil {
-				panic(err)
+				return nil, err
 			}
 			errObj := &Error{
 				Name:   field.Name,

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Ethernal-Tech/ethgo/compiler"
 	"github.com/Ethernal-Tech/ethgo/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func mustDecodeHex(str string) []byte {
@@ -775,14 +776,12 @@ func TestEncodingStruct_dynamicTuple(t *testing.T) {
 	}
 
 	encoded, err := typ.Encode(&obj)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var obj2 Obj
-	if err := typ.DecodeStruct(encoded, &obj2); err != nil {
-		t.Fatal(err)
-	}
+	err = typ.DecodeStruct(encoded, &obj2)
+	require.NoError(t, err)
+
 	if !reflect.DeepEqual(obj, obj2) {
 		t.Fatal("bad")
 	}

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -335,49 +335,6 @@ func TestEncoding(t *testing.T) {
 	}
 }
 
-func TestEncoding2(t *testing.T) {
-	cases := []struct {
-		Type  string
-		Input interface{}
-	}{
-		{
-			"tuple(bytes a)[]",
-			[]map[string]interface{}{
-				{
-					"a": []byte{
-						0xff,
-						0xff,
-					},
-				},
-				{
-					"a": []byte{
-						0xff,
-						0xff,
-					},
-				},
-			},
-		},
-	}
-
-	server := testutil.NewTestServer(t)
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.Type, func(t *testing.T) {
-			t.Parallel()
-
-			tt, err := NewType(c.Type)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if err := testEncodeDecode(t, server, tt, c.Input); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
-
 func TestEncodingBestEffort(t *testing.T) {
 	strAddress := "0xdbb881a51CD4023E4400CEF3ef73046743f08da3"
 	ethAddress := ethgo.HexToAddress(strAddress)

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -335,6 +335,49 @@ func TestEncoding(t *testing.T) {
 	}
 }
 
+func TestEncoding2(t *testing.T) {
+	cases := []struct {
+		Type  string
+		Input interface{}
+	}{
+		{
+			"tuple(bytes a)[]",
+			[]map[string]interface{}{
+				{
+					"a": []byte{
+						0xff,
+						0xff,
+					},
+				},
+				{
+					"a": []byte{
+						0xff,
+						0xff,
+					},
+				},
+			},
+		},
+	}
+
+	server := testutil.NewTestServer(t)
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Type, func(t *testing.T) {
+			t.Parallel()
+
+			tt, err := NewType(c.Type)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := testEncodeDecode(t, server, tt, c.Input); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestEncodingBestEffort(t *testing.T) {
 	strAddress := "0xdbb881a51CD4023E4400CEF3ef73046743f08da3"
 	ethAddress := ethgo.HexToAddress(strAddress)
@@ -566,6 +609,7 @@ func TestEncodingArguments(t *testing.T) {
 
 func testEncodeDecode(t *testing.T, server *testutil.TestServer, tt *Type, input interface{}) error {
 	res1, err := Encode(input, tt)
+	fmt.Println(res1)
 	if err != nil {
 		return err
 	}

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -566,7 +566,6 @@ func TestEncodingArguments(t *testing.T) {
 
 func testEncodeDecode(t *testing.T, server *testutil.TestServer, tt *Type, input interface{}) error {
 	res1, err := Encode(input, tt)
-	fmt.Println(res1)
 	if err != nil {
 		return err
 	}

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -504,13 +504,13 @@ func TestEncodingBestEffort(t *testing.T) {
 
 func TestEncodingArguments(t *testing.T) {
 	cases := []struct {
-		Arg   *ArgumentStr
+		Arg   *compiler.IOField
 		Input interface{}
 	}{
 		{
-			&ArgumentStr{
+			&compiler.IOField{
 				Type: "tuple",
-				Components: []*ArgumentStr{
+				Components: []*compiler.IOField{
 					{
 						Name: "",
 						Type: "int32",
@@ -527,9 +527,9 @@ func TestEncodingArguments(t *testing.T) {
 			},
 		},
 		{
-			&ArgumentStr{
+			&compiler.IOField{
 				Type: "tuple",
-				Components: []*ArgumentStr{
+				Components: []*compiler.IOField{
 					{
 						Name: "a",
 						Type: "int32",
@@ -551,7 +551,7 @@ func TestEncodingArguments(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			tt, err := NewTypeFromArgument(c.Arg)
+			tt, err := NewTypeFromField(c.Arg)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/abi/testing.go
+++ b/abi/testing.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Ethernal-Tech/ethgo"
+	"github.com/Ethernal-Tech/ethgo/compiler"
 )
 
 func randomInt(min, max int) int {
@@ -192,7 +193,7 @@ func (g *generateContractImpl) run(t *Type) string {
 	}
 
 	contractTemplate :=
-		`pragma solidity ^0.8.19;
+		`pragma solidity ^%s;
 	
 	contract Sample {
 		// structs
@@ -204,6 +205,7 @@ func (g *generateContractImpl) run(t *Type) string {
 
 	contract := fmt.Sprintf(
 		contractTemplate,
+		compiler.SolcVersion,
 		strings.Join(g.structs, "\n"),
 		strings.Join(input, ","),
 		strings.Join(output, ","),

--- a/abi/testing.go
+++ b/abi/testing.go
@@ -191,16 +191,16 @@ func (g *generateContractImpl) run(t *Type) string {
 		body = append(body, fmt.Sprintf("arg%d", indx))
 	}
 
-	contractTemplate := `pragma solidity ^0.5.5;
-pragma experimental ABIEncoderV2;
-
-contract Sample {
-	// structs
-	%s
-	function set(%s) public view returns (%s) {
-		return (%s);
-	}
-}`
+	contractTemplate :=
+		`pragma solidity ^0.8.19;
+	
+	contract Sample {
+		// structs
+		%s
+		function set(%s) public view returns (%s) {
+			return (%s);
+		}
+	}`
 
 	contract := fmt.Sprintf(
 		contractTemplate,

--- a/abi/topics_test.go
+++ b/abi/topics_test.go
@@ -106,7 +106,7 @@ func TestIntegrationTopics(t *testing.T) {
 		require.NoError(t, err)
 
 		// read the abi
-		abi, err := NewABI(artifact.Abi)
+		abi, err := NewABIFromSlice(artifact.Abi)
 		assert.NoError(t, err)
 
 		// parse the logs

--- a/abi/type.go
+++ b/abi/type.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Ethernal-Tech/ethgo"
+	"github.com/Ethernal-Tech/ethgo/compiler"
 )
 
 // batch of predefined reflect types
@@ -115,10 +116,10 @@ func NewTupleType(inputs []*TupleElem) *Type {
 	}
 }
 
-func NewTupleTypeFromArgs(inputs []*ArgumentStr) (*Type, error) {
+func NewTupleTypeFromFields(inputs []*compiler.IOField) (*Type, error) {
 	elems := []*TupleElem{}
 	for _, i := range inputs {
-		typ, err := NewTypeFromArgument(i)
+		typ, err := NewTypeFromField(i)
 		if err != nil {
 			return nil, err
 		}
@@ -255,7 +256,7 @@ func (t *Type) isDynamicType() bool {
 	return t.kind == KindString || t.kind == KindBytes || t.kind == KindSlice || (t.kind == KindArray && t.elem.isDynamicType())
 }
 
-func parseType(arg *ArgumentStr) (string, error) {
+func parseType(arg *compiler.IOField) (string, error) {
 	if !strings.HasPrefix(arg.Type, "tuple") {
 		return arg.Type, nil
 	}
@@ -280,8 +281,8 @@ func parseType(arg *ArgumentStr) (string, error) {
 	return fmt.Sprintf("tuple(%s)%s", strings.Join(str, ","), strings.TrimPrefix(arg.Type, "tuple")), nil
 }
 
-// NewTypeFromArgument parses an abi type from an argument
-func NewTypeFromArgument(arg *ArgumentStr) (*Type, error) {
+// NewTypeFromField parses an abi type from an argument
+func NewTypeFromField(arg *compiler.IOField) (*Type, error) {
 	str, err := parseType(arg)
 	if err != nil {
 		return nil, err
@@ -299,7 +300,7 @@ func NewTypeFromArgument(arg *ArgumentStr) (*Type, error) {
 	return typ, nil
 }
 
-func fillIn(typ *Type, arg *ArgumentStr) error {
+func fillIn(typ *Type, arg *compiler.IOField) error {
 	typ.itype = arg.InternalType
 
 	if len(arg.Components) == 0 {

--- a/abi/type_test.go
+++ b/abi/type_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Ethernal-Tech/ethgo/compiler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +12,7 @@ import (
 func TestType(t *testing.T) {
 	cases := []struct {
 		s   string
-		a   *ArgumentStr
+		a   *compiler.IOField
 		t   *Type
 		r   string
 		err bool
@@ -111,9 +112,9 @@ func TestType(t *testing.T) {
 		},
 		{
 			s: "tuple(int64 indexed arg0)",
-			a: &ArgumentStr{
+			a: &compiler.IOField{
 				Type: "tuple",
-				Components: []*ArgumentStr{
+				Components: []*compiler.IOField{
 					{
 						Name:    "arg0",
 						Type:    "int64",
@@ -139,9 +140,9 @@ func TestType(t *testing.T) {
 		},
 		{
 			s: "tuple(int64 arg_0)[2]",
-			a: &ArgumentStr{
+			a: &compiler.IOField{
 				Type: "tuple[2]",
-				Components: []*ArgumentStr{
+				Components: []*compiler.IOField{
 					{
 						Name: "arg_0",
 						Type: "int64",
@@ -170,9 +171,9 @@ func TestType(t *testing.T) {
 		},
 		{
 			s: "tuple(int64 a)[]",
-			a: &ArgumentStr{
+			a: &compiler.IOField{
 				Type: "tuple[]",
-				Components: []*ArgumentStr{
+				Components: []*compiler.IOField{
 					{
 						Name: "a",
 						Type: "int64",
@@ -200,9 +201,9 @@ func TestType(t *testing.T) {
 		},
 		{
 			s: "tuple(int32 indexed arg0,tuple(int32 c) b_2)",
-			a: &ArgumentStr{
+			a: &compiler.IOField{
 				Type: "tuple",
-				Components: []*ArgumentStr{
+				Components: []*compiler.IOField{
 					{
 						Name:    "arg0",
 						Type:    "int32",
@@ -211,7 +212,7 @@ func TestType(t *testing.T) {
 					{
 						Name: "b_2",
 						Type: "tuple",
-						Components: []*ArgumentStr{
+						Components: []*compiler.IOField{
 							{
 								Name: "c",
 								Type: "int32",
@@ -255,9 +256,9 @@ func TestType(t *testing.T) {
 		},
 		{
 			s: "tuple()",
-			a: &ArgumentStr{
+			a: &compiler.IOField{
 				Type:       "tuple",
-				Components: []*ArgumentStr{},
+				Components: []*compiler.IOField{},
 			},
 			t: &Type{
 				kind:  KindTuple,
@@ -268,12 +269,12 @@ func TestType(t *testing.T) {
 		{
 			// hidden tuple token
 			s: "tuple((int32))",
-			a: &ArgumentStr{
+			a: &compiler.IOField{
 				Type: "tuple",
-				Components: []*ArgumentStr{
+				Components: []*compiler.IOField{
 					{
 						Type: "tuple",
-						Components: []*ArgumentStr{
+						Components: []*compiler.IOField{
 							{
 								Type: "int32",
 							},
@@ -344,7 +345,7 @@ func TestType(t *testing.T) {
 				}
 				assert.Equal(t, expected, e0.Format(true))
 
-				e1, err := NewTypeFromArgument(c.a)
+				e1, err := NewTypeFromField(c.a)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -365,12 +366,12 @@ func TestType(t *testing.T) {
 }
 
 func TestTypeArgument_InternalFields(t *testing.T) {
-	arg := &ArgumentStr{
+	arg := &compiler.IOField{
 		Type: "tuple",
-		Components: []*ArgumentStr{
+		Components: []*compiler.IOField{
 			{
 				Type: "tuple[]",
-				Components: []*ArgumentStr{
+				Components: []*compiler.IOField{
 					{
 						Type:         "int32",
 						InternalType: "c",
@@ -381,7 +382,7 @@ func TestTypeArgument_InternalFields(t *testing.T) {
 		},
 	}
 
-	res, err := NewTypeFromArgument(arg)
+	res, err := NewTypeFromField(arg)
 	require.NoError(t, err)
 
 	require.Equal(t, res.tuple[0].Elem.itype, "b")
@@ -432,8 +433,8 @@ func TestSize(t *testing.T) {
 	}
 }
 
-func simpleType(s string) *ArgumentStr {
-	return &ArgumentStr{
+func simpleType(s string) *compiler.IOField {
+	return &compiler.IOField{
 		Type: s,
 	}
 }

--- a/compiler/fixtures/ballot.sol
+++ b/compiler/fixtures/ballot.sol
@@ -1,4 +1,5 @@
-pragma solidity >=0.4.22 <0.6.0;
+/* SPDX-License-Identifier: UNLICENSED */
+pragma solidity >=0.4.22 <0.8.29;
 
 /// @title Voting with delegation.
 contract Ballot {
@@ -28,7 +29,7 @@ contract Ballot {
     Proposal[] public proposals;
 
     /// Create a new ballot to choose one of `proposalNames`.
-    constructor(bytes32[] memory proposalNames) public {
+    constructor(bytes32[] memory proposalNames) {
         chairperson = msg.sender;
         voters[chairperson].weight = 1;
 

--- a/compiler/fixtures/simple_auction.sol
+++ b/compiler/fixtures/simple_auction.sol
@@ -1,4 +1,5 @@
-pragma solidity >=0.4.22 <0.6.0;
+/* SPDX-License-Identifier: UNLICENSED */
+pragma solidity >=0.4.22 <0.8.29;
 
 contract SimpleAuction {
     // Parameters of the auction. Times are either
@@ -33,9 +34,9 @@ contract SimpleAuction {
     constructor(
         uint _biddingTime,
         address payable _beneficiary
-    ) public {
+    ) {
         beneficiary = _beneficiary;
-        auctionEndTime = now + _biddingTime;
+        auctionEndTime = block.timestamp + _biddingTime;
     }
 
     /// Bid on the auction with the value sent
@@ -52,7 +53,7 @@ contract SimpleAuction {
         // Revert the call if the bidding
         // period is over.
         require(
-            now <= auctionEndTime,
+            block.timestamp <= auctionEndTime,
             "Auction already ended."
         );
 
@@ -77,7 +78,7 @@ contract SimpleAuction {
     }
 
     /// Withdraw a bid that was overbid.
-    function withdraw() public returns (bool) {
+    function withdraw() public payable returns (bool) {
         uint amount = pendingReturns[msg.sender];
         if (amount > 0) {
             // It is important to set this to zero because the recipient
@@ -85,7 +86,7 @@ contract SimpleAuction {
             // before `send` returns.
             pendingReturns[msg.sender] = 0;
 
-            if (!msg.sender.send(amount)) {
+            if (!payable(msg.sender).send(amount)) {
                 // No need to call throw here, just reset the amount owing
                 pendingReturns[msg.sender] = amount;
                 return false;
@@ -111,7 +112,7 @@ contract SimpleAuction {
         // external contracts.
 
         // 1. Conditions
-        require(now >= auctionEndTime, "Auction not yet ended.");
+        require(block.timestamp >= auctionEndTime, "Auction not yet ended.");
         require(!ended, "auctionEnd has already been called.");
 
         // 2. Effects

--- a/compiler/solidity.go
+++ b/compiler/solidity.go
@@ -24,21 +24,21 @@ type Source struct {
 }
 
 type IOField struct {
-	Name         string    `json:"name"`
-	Type         string    `json:"type"`
-	Indexed      bool      `json:"indexed"`
-	Components   []IOField `json:"components"`
-	InternalType string    `json:"internalType"`
+	Name         string     `json:"name"`
+	Type         string     `json:"type"`
+	Indexed      bool       `json:"indexed"`
+	Components   []*IOField `json:"components"`
+	InternalType string     `json:"internalType"`
 }
 
 type AbiField struct {
-	Type            string    `json:"type"`
-	Name            string    `json:"name"`
-	Inputs          []IOField `json:"inputs"`
-	Outputs         []IOField `json:"outputs"`
-	StateMutability string    `json:"stateMutability"`
-	Anonymous       bool      `json:"anonymous"`
-	Constant        bool      `json:"constant"`
+	Type            string     `json:"type"`
+	Name            string     `json:"name"`
+	Inputs          []*IOField `json:"inputs"`
+	Outputs         []*IOField `json:"outputs"`
+	StateMutability string     `json:"stateMutability"`
+	Anonymous       bool       `json:"anonymous"`
+	Constant        bool       `json:"constant"`
 }
 
 type Artifact struct {

--- a/compiler/solidity.go
+++ b/compiler/solidity.go
@@ -23,8 +23,26 @@ type Source struct {
 	AST map[string]interface{}
 }
 
+type IOField struct {
+	Name         string    `json:"name"`
+	Type         string    `json:"type"`
+	Indexed      bool      `json:"indexed"`
+	Components   []IOField `json:"components"`
+	InternalType string    `json:"internalType"`
+}
+
+type AbiField struct {
+	Type            string    `json:"type"`
+	Name            string    `json:"name"`
+	Inputs          []IOField `json:"inputs"`
+	Outputs         []IOField `json:"outputs"`
+	StateMutability string    `json:"stateMutability"`
+	Anonymous       bool      `json:"anonymous"`
+	Constant        bool      `json:"constant"`
+}
+
 type Artifact struct {
-	Abi           string
+	Abi           []AbiField `json:"abi"`
 	Bin           string
 	BinRuntime    string `json:"bin-runtime"`
 	SrcMap        string `json:"srcmap"`
@@ -83,7 +101,7 @@ func (s *Solidity) compileImpl(code string, files ...string) (*Output, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to compile: %s", string(stderr.Bytes()))
+		return nil, fmt.Errorf("failed to compile: %s", stderr.String())
 	}
 
 	var output *Output

--- a/compiler/solidity.go
+++ b/compiler/solidity.go
@@ -13,6 +13,10 @@ import (
 	"strings"
 )
 
+const (
+	SolcVersion = "0.8.19"
+)
+
 type Output struct {
 	Contracts map[string]*Artifact
 	Sources   map[string]*Source

--- a/compiler/solidity_test.go
+++ b/compiler/solidity_test.go
@@ -119,7 +119,7 @@ func existsSolidity(t *testing.T, path string) bool {
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		t.Fatalf("solidity version failed: %s", string(stderr.Bytes()))
+		t.Fatalf("solidity version failed: %s", stderr.String())
 	}
 	if len(stdout.Bytes()) == 0 {
 		t.Fatal("empty output")

--- a/compiler/solidity_test.go
+++ b/compiler/solidity_test.go
@@ -28,7 +28,7 @@ func init() {
 		panic(err)
 	}
 	// solc folder does not exists
-	if err := DownloadSolidity("0.8.19", solcDir, false); err != nil {
+	if err := DownloadSolidity(SolcVersion, solcDir, false); err != nil {
 		panic(err)
 	}
 }
@@ -134,13 +134,13 @@ func TestDownloadSolidityCompiler(t *testing.T) {
 	}
 	defer os.RemoveAll(dst1)
 
-	if err := DownloadSolidity("0.8.19", dst1, true); err != nil {
+	if err := DownloadSolidity(SolcVersion, dst1, true); err != nil {
 		t.Fatal(err)
 	}
 	if existsSolidity(t, filepath.Join(dst1, "solidity")) {
 		t.Fatal("it should not exist")
 	}
-	if !existsSolidity(t, filepath.Join(dst1, "solidity-0.8.19")) {
+	if !existsSolidity(t, filepath.Join(dst1, "solidity-"+SolcVersion)) {
 		t.Fatal("it should exist")
 	}
 
@@ -150,13 +150,13 @@ func TestDownloadSolidityCompiler(t *testing.T) {
 	}
 	defer os.RemoveAll(dst2)
 
-	if err := DownloadSolidity("0.8.19", dst2, false); err != nil {
+	if err := DownloadSolidity(SolcVersion, dst2, false); err != nil {
 		t.Fatal(err)
 	}
 	if !existsSolidity(t, filepath.Join(dst2, "solidity")) {
 		t.Fatal("it should exist")
 	}
-	if existsSolidity(t, filepath.Join(dst2, "solidity-0.8.19")) {
+	if existsSolidity(t, filepath.Join(dst2, "solidity-"+SolcVersion)) {
 		t.Fatal("it should not exist")
 	}
 }

--- a/compiler/solidity_test.go
+++ b/compiler/solidity_test.go
@@ -28,7 +28,7 @@ func init() {
 		panic(err)
 	}
 	// solc folder does not exists
-	if err := DownloadSolidity("0.5.5", solcDir, false); err != nil {
+	if err := DownloadSolidity("0.8.19", solcDir, false); err != nil {
 		panic(err)
 	}
 }
@@ -134,13 +134,13 @@ func TestDownloadSolidityCompiler(t *testing.T) {
 	}
 	defer os.RemoveAll(dst1)
 
-	if err := DownloadSolidity("0.5.5", dst1, true); err != nil {
+	if err := DownloadSolidity("0.8.19", dst1, true); err != nil {
 		t.Fatal(err)
 	}
 	if existsSolidity(t, filepath.Join(dst1, "solidity")) {
 		t.Fatal("it should not exist")
 	}
-	if !existsSolidity(t, filepath.Join(dst1, "solidity-0.5.5")) {
+	if !existsSolidity(t, filepath.Join(dst1, "solidity-0.8.19")) {
 		t.Fatal("it should exist")
 	}
 
@@ -150,13 +150,13 @@ func TestDownloadSolidityCompiler(t *testing.T) {
 	}
 	defer os.RemoveAll(dst2)
 
-	if err := DownloadSolidity("0.5.5", dst2, false); err != nil {
+	if err := DownloadSolidity("0.8.19", dst2, false); err != nil {
 		t.Fatal(err)
 	}
 	if !existsSolidity(t, filepath.Join(dst2, "solidity")) {
 		t.Fatal("it should exist")
 	}
-	if existsSolidity(t, filepath.Join(dst2, "solidity-0.5.5")) {
+	if existsSolidity(t, filepath.Join(dst2, "solidity-0.8.19")) {
 		t.Fatal("it should not exist")
 	}
 }

--- a/compiler/solidity_test.go
+++ b/compiler/solidity_test.go
@@ -19,7 +19,7 @@ var (
 )
 
 func init() {
-	_, err := os.Stat(solcDir)
+	_, err := os.Stat(solcPath)
 	if err == nil {
 		// already exists
 		return

--- a/scripts/setup-ci.sh
+++ b/scripts/setup-ci.sh
@@ -3,7 +3,7 @@
 # set -o errexit
 
 install_solidity() {
-    VERSION="0.5.5"
+    VERSION="0.8.19"
     DOWNLOAD=https://github.com/ethereum/solidity/releases/download/v${VERSION}/solc-static-linux
 
     curl -L $DOWNLOAD > /tmp/solc

--- a/testutil/contract.go
+++ b/testutil/contract.go
@@ -38,8 +38,7 @@ func (c *Contract) GetEvent(name string) *Event {
 
 // Print prints the contract
 func (c *Contract) Print() string {
-	str := "pragma solidity ^0.5.5;\n"
-	str += "pragma experimental ABIEncoderV2;\n"
+	str := "pragma solidity ^0.8.19;\n"
 	str += "\n"
 	str += "contract Sample {\n"
 

--- a/testutil/contract.go
+++ b/testutil/contract.go
@@ -38,7 +38,7 @@ func (c *Contract) GetEvent(name string) *Event {
 
 // Print prints the contract
 func (c *Contract) Print() string {
-	str := "pragma solidity ^0.8.19;\n"
+	str := "pragma solidity ^" + compiler.SolcVersion + ";\n"
 	str += "\n"
 	str += "contract Sample {\n"
 


### PR DESCRIPTION
Upgrading Solidity compiler version from **0.5.5** to **0.8.19**. 

With that update it is leaving `experimental ABIEncoderV2` to standard `ABIEncoderV2`.

